### PR TITLE
Fix Makefile to use xtensa-lx106-elf-ar

### DIFF
--- a/Makefile.open
+++ b/Makefile.open
@@ -1,0 +1,54 @@
+CC = xtensa-lx106-elf-gcc
+DEFS = -DLWIP_OPEN_SRC -DPBUF_RSV_FOR_WLAN -DEBUF_LWIP -DICACHE_FLASH
+COPT = -Os
+CFLAGS = $(DEFS) $(COPT) -Iinclude -Wl,-EL -mlongcalls -mtext-section-literals
+# Install prefix of esp-open-sdk toolchain
+PREFIX = ~/toolchain/xtensa-lx106-elf
+
+
+OBJS = \
+lwip/core/def.o \
+lwip/core/dhcp.o \
+lwip/core/dns.o \
+lwip/core/init.o \
+lwip/core/mem.o \
+lwip/core/memp.o \
+lwip/core/netif.o \
+lwip/core/pbuf.o \
+lwip/core/raw.o \
+lwip/core/sntp.o \
+lwip/core/stats.o \
+lwip/core/sys_arch.o \
+lwip/core/sys.o \
+lwip/core/tcp.o \
+lwip/core/tcp_in.o \
+lwip/core/tcp_out.o \
+lwip/core/timers.o \
+lwip/core/udp.o \
+lwip/core/ipv4/autoip.o \
+lwip/core/ipv4/icmp.o \
+lwip/core/ipv4/igmp.o \
+lwip/core/ipv4/inet.o \
+lwip/core/ipv4/inet_chksum.o \
+lwip/core/ipv4/ip_addr.o \
+lwip/core/ipv4/ip.o \
+lwip/core/ipv4/ip_frag.o \
+lwip/netif/etharp.o \
+\
+lwip/app/dhcpserver.o \
+\
+espconn_dummy.o \
+
+LIB = liblwip_open.a
+
+all: $(LIB)
+
+
+$(LIB): $(OBJS)
+	$(AR) rcs $@ $^
+
+install: $(LIB)
+	cp $(LIB) $(PREFIX)/xtensa-lx106-elf/sysroot/usr/lib/
+
+clean:
+	rm -f $(OBJS)

--- a/Makefile.open
+++ b/Makefile.open
@@ -1,4 +1,5 @@
 CC = xtensa-lx106-elf-gcc
+AR = xtensa-lx106-elf-ar
 DEFS = -DLWIP_OPEN_SRC -DPBUF_RSV_FOR_WLAN -DEBUF_LWIP -DICACHE_FLASH
 COPT = -Os
 CFLAGS = $(DEFS) $(COPT) -Iinclude -Wl,-EL -mlongcalls -mtext-section-literals

--- a/espconn_dummy.c
+++ b/espconn_dummy.c
@@ -1,0 +1,5 @@
+#include <c_types.h>
+
+void ICACHE_FLASH_ATTR espconn_init(void)
+{
+}

--- a/lwip/core/ipv4/ip_addr.c
+++ b/lwip/core/ipv4/ip_addr.c
@@ -114,7 +114,7 @@ ip4_addr_netmask_valid(u32_t netmask)
 #define in_range(c, lo, up)  ((u8_t)c >= lo && (u8_t)c <= up)
 #define isprint(c)           in_range(c, 0x20, 0x7f)
 //#define isdigit(c)           in_range(c, '0', '9')
-//#define isxdigit(c)          (isdigit(c) || in_range(c, 'a', 'f') || in_range(c, 'A', 'F'))
+#define isxdigit(c)          (isdigit(c) || in_range(c, 'a', 'f') || in_range(c, 'A', 'F'))
 #define islower(c)           in_range(c, 'a', 'z')
 #define isspace(c)           (c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v')
 #endif


### PR DESCRIPTION
`Makefile.open` has a problem that using system default `ar` for linking esp8266 binary.

This PR sets `AR` to use `xtensa-lx106-elf-ar`
