### PR TITLE
Remove liblwip_open.a during clean

### DIFF
--- a/Makefile.open
+++ b/Makefile.open
@@ -52,4 +52,4 @@ install: $(LIB)
 	cp $(LIB) $(PREFIX)/xtensa-lx106-elf/sysroot/usr/lib/
 
 clean:
-	rm -f $(OBJS)
+	rm -f $(OBJS) $(LIB)


### PR DESCRIPTION
In addition to the object files, liblwip_open.a should be removed during clean.
