### PR TITLE
Fix compile warnings

### DIFF
--- a/include/arch/cc.h
+++ b/include/arch/cc.h
@@ -38,7 +38,23 @@
 #include "c_types.h"
 #include "ets_sys.h"
 #include "osapi.h"
+#include <stdarg.h>
+
 #define EFAULT 14
+
+//Extra symbols to avoid implicit declaration warnings
+extern void *ets_memset(void *s, int c, size_t n);
+extern void ets_memcpy(void*, const void*, uint32);
+
+extern size_t ets_strlen(const char *s);
+extern int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
+extern int ets_sprintf(char *str, const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
+extern void ets_timer_arm_new(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag, int isMstimer);
+extern void ets_timer_disarm(ETSTimer *a);
+extern void ets_timer_setfn(ETSTimer *t, ETSTimerFunc *pfunction, void *parg);
+extern uint32 r_rand(void);
+extern int ets_memcmp(const void *s1, const void *s2, size_t n);
+struct netif * eagle_lwip_getif(uint8 index);
 
 //#define LWIP_PROVIDE_ERRNO
 

--- a/lwip/app/dhcpserver.c
+++ b/lwip/app/dhcpserver.c
@@ -13,6 +13,8 @@
 
 #include "user_interface.h"
 
+extern int wifi_softap_set_station_info(uint8_t * chaddr, struct ip_addr *ip);
+
 #ifdef MEMLEAK_DEBUG
 static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;
 #endif

--- a/lwip/core/dhcp.c
+++ b/lwip/core/dhcp.c
@@ -84,6 +84,8 @@
 
 #include <string.h>
 
+extern void system_station_got_ip_set(ip_addr_t * ip_addr, ip_addr_t *sn_mask, ip_addr_t *gw_addr);
+
 #ifdef MEMLEAK_DEBUG
 static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;
 #endif

--- a/lwip/core/ipv4/ip_addr.c
+++ b/lwip/core/ipv4/ip_addr.c
@@ -40,6 +40,8 @@
 #include "lwip/ip_addr.h"
 #include "lwip/netif.h"
 
+extern int isdigit ( int c );
+
 /* used by IP_ADDR_ANY and IP_ADDR_BROADCAST in ip_addr.h */
 const ip_addr_t ip_addr_any ICACHE_RODATA_ATTR = { IPADDR_ANY };
 const ip_addr_t ip_addr_broadcast ICACHE_RODATA_ATTR = { IPADDR_BROADCAST };


### PR DESCRIPTION
Fix warning: implicit function declaration by defining correspondinng espressif functions that will be linked from other libs later on.