### PR TITLE
Backported a fix for wrong segment size calculation.

### DIFF
--- a/lwip/core/tcp_out.c
+++ b/lwip/core/tcp_out.c
@@ -448,7 +448,7 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u16_t len, u8_t apiflags)
     if (oversize > 0) {
       LWIP_ASSERT("inconsistent oversize vs. space", oversize_used <= space);
       seg = last_unsent;
-      oversize_used = oversize < len ? oversize : len;
+      oversize_used = LWIP_MIN(space, LWIP_MIN(oversize, len));
       pos += oversize_used;
       oversize -= oversize_used;
       space -= oversize_used;


### PR DESCRIPTION
Original fix is here: https://github.com/lwip-tcpip/lwip/commit/8e8571da6a6771f9d2d82bbd0b5a6c27474ce0fc

Issue spotted and documented here: https://github.com/SmingHub/Sming/issues/2654